### PR TITLE
Replace `yaml.safeLoad` with `yaml.load` for `local-file`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ try {
         fs.readFile(metadataFilePath, 'utf8')
             .then(data => {
                 console.debug(`File found ${metadataFilePath}`);
-                let metadata = yaml.safeLoad(data);
+                let metadata = yaml.load(data);
                 setOutputs(metadata);
             })
             .catch(err => {


### PR DESCRIPTION
Fixes error:
`Error: Could not read project metadata file: Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.`


Reference: https://github.com/eyefloaters/console/actions/runs/7195501553/job/19598276802