### PR TITLE
Bump to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
- Fixes #15

This gets rid of the warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: radcortez/project-metadata-action@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```